### PR TITLE
Quiet parsing option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -45,11 +45,11 @@ switch (argv._[0]) {
 
     if (needsHelp || !codePath)
       usage("parse <code-file>", [
-        "Parse the given file using the parser in the current working directory.",
+        "Parse the given file using the parser in the current working directory and print the sytax tree.",
         "",
         "Arguments",
         "  code-path          - The file to parse",
-        "  --print, -p        - Print the syntax tree",
+        "  --quiet, -q        - Parse, but don't print any output",
         "  --debug, -d        - Print a log of parse actions",
         "  --debug-graph, -D  - Render a sequence of diagrams showing the changing parse stack",
         "  --profile, -P      - Render a flame graph of the parse performance (requires sudo)",
@@ -60,7 +60,7 @@ switch (argv._[0]) {
       codePath: argv._[1],
       debugGraph: argv['debug-graph'] || argv.D,
       debug: argv.debug || argv.d,
-      print: argv.print || argv.p,
+      quiet: argv.quiet || argv.q,
       profile: argv.profile || argv.P,
       repeat: argv.repeat
     }, process.exit);

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -91,12 +91,11 @@ module.exports = function parse(options, callback) {
   }
   var t1 = Date.now();
 
-  if (options.print) {
+  if (!options.quiet) {
     printNode(document.rootNode, 0);
     process.stdout.write("\n");
+    console.log("Parsed in %d milliseconds", (t1 - t0) / options.repeat);
   }
-
-  console.log("Parsed in %d milliseconds", (t1 - t0) / options.repeat);
 
   if (!document.rootNode) {
     console.log("Memory allocation failed");

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -91,9 +91,12 @@ module.exports = function parse(options, callback) {
   }
   var t1 = Date.now();
 
-  if (!options.quiet) {
+  if (!options.quiet && !options.debug && !options.debugGraph) {
     printNode(document.rootNode, 0);
     process.stdout.write("\n");
+  }
+
+  if (!options.quiet) {
     console.log("Parsed in %d milliseconds", (t1 - t0) / options.repeat);
   }
 

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -101,12 +101,33 @@ module.exports = function parse(options, callback) {
     console.log("Memory allocation failed");
     callback(1)
   } else if (document.rootNode.toString().indexOf('ERROR') !== -1) {
-    console.log("Error detected")
+    printFirstErrorNode(document.rootNode, options.codePath);
     callback(1);
   } else {
     callback(0);
   }
 };
+
+function printFirstErrorNode(node, path) {
+  if (node.type === 'ERROR') {
+    errorString = "Error parsing ";
+    errorString += path;
+    errorString += " (";
+    errorString += node.type
+    errorString += " ";
+    errorString += pointString(node.startPosition);
+    errorString += " - ";
+    errorString += pointString(node.endPosition);
+    errorString += ")";
+    console.log(errorString);
+    return true;
+  }
+
+  var children = node.namedChildren;
+  for (var i = 0, length = children.length; i < length; i++) {
+    if(printFirstErrorNode(children[i], path)) return true;
+  }
+}
 
 function printNode (node, indentLevel) {
   process.stdout.write(new Array(2 * indentLevel + 1).join(' '));


### PR DESCRIPTION
Removes the print (`-p`) option from `parse` and prints the tree by default. Adds a new quiet option (`-q`) that hides this output if so desired. My thinking is that the default use of the `parse` command is always printing the tree to stdout. Hiding that output is a special case of just wanting to know if parsing succeeded or failed (potentially useful for automated testing).

As part of this, I also improved on the error output when parsing fails by printing the path parsed and the range of the first error node.