### PR TITLE
Allow test files to have CRLF

### DIFF
--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -46,7 +46,7 @@ function suiteForPath(filepath, document) {
     var content = fs.readFileSync(filepath, "utf8");
 
     for (;;) {
-      var headerMatch = content.match(/===+\n([^\n=]+)\n===+/),
+      var headerMatch = content.match(/===+[\r\n]+([^\r\n=]+)[\r\n]+===+/),
           dividerMatch = content.match(/\n(---+)/);
 
       if (!headerMatch || !dividerMatch)
@@ -56,7 +56,7 @@ function suiteForPath(filepath, document) {
           inputStart = headerMatch[0].length,
           inputEnd = dividerMatch.index,
           outputStart = dividerMatch.index + dividerMatch[1].length + 1,
-          nextTestStart = content.slice(outputStart).search(/\n===/),
+          nextTestStart = content.slice(outputStart).search(/\r?\n===/),
           outputEnd = (nextTestStart > 0) ? (nextTestStart + outputStart) : content.length;
 
       (function() {

--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -46,7 +46,7 @@ function suiteForPath(filepath, document) {
     var content = fs.readFileSync(filepath, "utf8");
 
     for (;;) {
-      var headerMatch = content.match(/===+[\r\n]+([^\r\n=]+)[\r\n]+===+/),
+      var headerMatch = content.match(/===+\r?\n([^\r\n=]+)\r?\n===+/),
           dividerMatch = content.match(/\n(---+)/);
 
       if (!headerMatch || !dividerMatch)


### PR DESCRIPTION
Needed the ability to have a test file with `CRLF` line endings so that we can verify parsing of code files with different line endings.