### PR TITLE
Fix issue to be able to run multiple crlf tests

### DIFF
--- a/lib/cli/test.js
+++ b/lib/cli/test.js
@@ -47,7 +47,7 @@ function suiteForPath(filepath, document) {
 
     for (;;) {
       var headerMatch = content.match(/===+\r?\n([^\r\n=]+)\r?\n===+/),
-          dividerMatch = content.match(/\n(---+)/);
+          dividerMatch = content.match(/\n(---+\r?\n)/);
 
       if (!headerMatch || !dividerMatch)
         break;
@@ -55,8 +55,8 @@ function suiteForPath(filepath, document) {
       var testName = headerMatch[1],
           inputStart = headerMatch[0].length,
           inputEnd = dividerMatch.index,
-          outputStart = dividerMatch.index + dividerMatch[1].length + 1,
-          nextTestStart = content.slice(outputStart).search(/\r?\n===/),
+          outputStart = dividerMatch.index + dividerMatch[1].length,
+          nextTestStart = content.slice(outputStart).search(/\n===/),
           outputEnd = (nextTestStart > 0) ? (nextTestStart + outputStart) : content.length;
 
       (function() {


### PR DESCRIPTION
Missed this in #15. The `+ 1` index math doesn't work if the line endings are two characters, this fixes that.