### PR TITLE
Add tests for async parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,13 @@
     "nan": "^2.0.0",
     "prettier": "^1.12.1",
     "temp": "0.8.x",
-    "tree-sitter": "^0.12.0",
+    "tree-sitter": "^0.12.1-0",
     "vows": "0.7.x"
   },
   "devDependencies": {
     "chai": "3.5.x",
     "jsonschema": "^1.0.3",
-    "mocha": "2.4.x"
+    "mocha": "2.4.x",
+    "superstring": "^2.3.1-0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "nan": "^2.0.0",
     "prettier": "^1.12.1",
     "temp": "0.8.x",
-    "tree-sitter": "^0.12.1-0",
+    "tree-sitter": "^0.12.2",
     "vows": "0.7.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "fs-extra": "^0.30.0",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
-    "nan": "^2.0.0",
+    "nan": "^2.10.0",
     "prettier": "^1.12.1",
     "temp": "0.8.x",
-    "tree-sitter": "^0.12.2",
+    "tree-sitter": "^0.12.3",
     "vows": "0.7.x"
   },
   "devDependencies": {

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -281,16 +281,35 @@ describe("Parser", () => {
       const messages = [];
       parser.setLogger(message => messages.push(message));
 
-      parser.parse('first-word second-word');
+      const tree1 = parser.parse('first-word second-word');
       assert(messages.length > 0);
       messages.length = 0;
 
       const buffer = new TextBuffer('first-word second-word');
-      await parser.parseTextBuffer(buffer);
+      const tree2 = await parser.parseTextBuffer(buffer);
       assert(messages.length === 0);
 
-      parser.parse('first-word second-word');
+      const tree3 = parser.parseTextBufferSync(buffer);
       assert(messages.length > 0);
+
+      assert.equal(tree2.rootNode.toString(), tree1.rootNode.toString())
+      assert.equal(tree3.rootNode.toString(), tree1.rootNode.toString())
+    })
+  });
+
+  describe('.parseTextBufferSync', () => {
+    it('parses the contents of the given text buffer synchronously', () => {
+      parser.setLanguage(language);
+      const buffer = new TextBuffer('αβ αβδ')
+      const tree = parser.parseTextBufferSync(buffer);
+      assert.equal(tree.rootNode.type, "sentence");
+      assert.equal(tree.rootNode.children.length, 2);
+    });
+
+    it('returns null if no language has been set', () => {
+      const buffer = new TextBuffer('αβ αβδ')
+      const tree = parser.parseTextBufferSync(buffer);
+      assert.equal(tree, null);
     })
   });
 });

--- a/test/parser_test.js
+++ b/test/parser_test.js
@@ -224,21 +224,18 @@ describe("Parser", () => {
       assert.equal(tree.rootNode.type, "sentence");
       assert.equal(tree.rootNode.children.length, wordCount);
 
-      const editPosition = repeatedString.length * 2;
+      const editIndex = repeatedString.length * 2;
       buffer.setTextInRange(
-        {
-          start: {row: 0, column: editPosition},
-          end: {row: 0, column: editPosition}
-        },
+        {start: {row: 0, column: editIndex}, end: {row: 0, column: editIndex}},
         'αβδ '
       );
       tree.edit({
-        startIndex: editPosition,
-        lengthAdded: 4,
-        lengthRemoved: 0,
-        startPosition: {row: 0, column: editPosition},
-        extentAdded: {row: 0, column: 4},
-        extentRemoved: {row: 0, column: 0}
+        startIndex: editIndex,
+        oldEndIndex: editIndex,
+        newEndIndex: editIndex + 4,
+        startPosition: {row: 0, column: editIndex},
+        oldEndPosition: {row: 0, column: editIndex},
+        newEndPosition: {row: 0, column: editIndex + 4}
       });
 
       const newTree = await parser.parseTextBuffer(buffer, tree);

--- a/test/tree_test.js
+++ b/test/tree_test.js
@@ -35,23 +35,26 @@ describe("Tree", () => {
 
     it("reports the ranges of text whose syntactic meaning has changed", () => {
       parser.setLanguage(language);
-      const tree1 = parser.parse("abcdefg + hij");
+
+      let sourceCode = "abcdefg + hij";
+      const tree1 = parser.parse(sourceCode);
 
       assert.equal(
         tree1.rootNode.toString(),
         "(expression (expression (variable)) (expression (variable)))"
       );
 
+      sourceCode = "abc + defg + hij";
       tree1.edit({
         startIndex: 2,
-        lengthAdded: 3,
-        lengthRemoved: 0,
+        oldEndIndex: 2,
+        newEndIndex: 5,
         startPosition: { row: 0, column: 2 },
-        extentAdded: { row: 0, column: 3 },
-        extentRemoved: { row: 0, column: 0 }
+        oldEndPosition: { row: 0, column: 2 },
+        newEndPosition: { row: 0, column: 5 }
       });
 
-      const tree2 = parser.parse("abc + defg + hij", tree1);
+      const tree2 = parser.parse(sourceCode, tree1);
       assert.equal(
         tree2.rootNode.toString(),
         "(expression (expression (expression (variable)) (expression (variable))) (expression (variable)))"
@@ -128,14 +131,17 @@ describe("Tree", () => {
 
     describe("when text is inserted", () => {
       it("updates the parse tree", () => {
+        const editIndex = "first-word ".length;
+        const insertedText = "first word ";
         input.text = "first-word first-word second-word first-word";
+
         tree.edit({
-          startIndex: "first-word ".length,
-          lengthAdded: "first-word ".length,
-          lengthRemoved: 0,
-          startPosition: { row: 0, column: "first-word ".length },
-          extentAdded: { row: 0, column: "first-word ".length },
-          extentRemoved: { row: 0, column: 0 }
+          startIndex: editIndex,
+          oldEndIndex: editIndex,
+          newEndIndex: editIndex + insertedText.length,
+          startPosition: { row: 0, column: editIndex },
+          oldEndPosition: { row: 0, column: editIndex },
+          newEndPosition: { row: 0, column: editIndex + insertedText.length }
         });
 
         tree = parser.parse(input, tree);
@@ -148,14 +154,17 @@ describe("Tree", () => {
 
     describe("when text is removed", () => {
       it("updates the parse tree", () => {
+        const editIndex = "first-word ".length;
+        const removedLength = "second-word ".length;
         input.text = "first-word first-word";
+
         tree.edit({
-          startIndex: "first-word ".length,
-          lengthAdded: 0,
-          lengthRemoved: "second-word ".length,
-          startPosition: { row: 0, column: "first-word ".length },
-          extentAdded: { row: 0, column: 0 },
-          extentRemoved: { row: 0, column: "second-word ".length }
+          startIndex: editIndex,
+          oldEndIndex: editIndex + removedLength,
+          newEndIndex: editIndex,
+          startPosition: { row: 0, column: editIndex },
+          oldEndPosition: { row: 0, column: editIndex + removedLength },
+          newEndPosition: { row: 0, column: editIndex }
         });
 
         tree = parser.parse(input, tree);
@@ -174,14 +183,17 @@ describe("Tree", () => {
       });
 
       it("updates the parse tree correctly", () => {
+        const editIndex = "αβ".length;
+        const insertedLength = "δ".length;
         input.text = "αβδ αβ αβ";
+
         tree.edit({
-          startIndex: 2,
-          lengthAdded: 1,
-          lengthRemoved: 0,
-          startPosition: { row: 0, column: 2 },
-          extentAdded: { row: 0, column: 1 },
-          extentRemoved: { row: 0, column: 0 }
+          startIndex: editIndex,
+          oldEndIndex: editIndex,
+          newEndIndex: editIndex + insertedLength,
+          startPosition: { row: 0, column: editIndex },
+          oldEndPosition: { row: 0, column: editIndex },
+          newEndPosition: { row: 0, column: editIndex + insertedLength }
         });
 
         tree = parser.parse(input, tree);

--- a/test/tree_test.js
+++ b/test/tree_test.js
@@ -275,7 +275,17 @@ describe("Tree", () => {
       assert.deepEqual(cursor.startIndex, 8);
       assert.deepEqual(cursor.endIndex, 13);
 
+      const childIndex = cursor.gotoFirstChildForIndex(12);
+      assert.equal(childIndex, 2);
+      assert.equal(cursor.nodeType, 'variable');
+      assert.equal(cursor.nodeIsNamed, true);
+      assert.deepEqual(cursor.startPosition, {row: 0, column: 12});
+      assert.deepEqual(cursor.endPosition, {row: 0, column: 13});
+      assert.deepEqual(cursor.startIndex, 12);
+      assert.deepEqual(cursor.endIndex, 13);
+
       assert(!cursor.gotoNextSibling());
+      assert(cursor.gotoParent());
       assert(cursor.gotoParent());
       assert(cursor.gotoParent());
       assert(!cursor.gotoParent());


### PR DESCRIPTION
This updates the tree-sitter runtime dependency and adds the tests for the functionality added in https://github.com/tree-sitter/node-tree-sitter/pull/11 and https://github.com/atom/superstring/pull/65.