### PR TITLE
Interpret arrays as sequences and implicitly sequence multiple rules

### DIFF
--- a/lib/api/dsl.js
+++ b/lib/api/dsl.js
@@ -101,14 +101,14 @@ function alias(rule, value) {
   throw new Error('Invalid alias value ' + value);
 }
 
-function repeat(rule) {
+function repeat(...rule) {
   return {
     type: "REPEAT",
     content: normalize(rule)
   };
 }
 
-function repeat1(rule) {
+function repeat1(...rule) {
   return {
     type: "REPEAT1",
     content: normalize(rule)
@@ -150,8 +150,8 @@ token.immediate = function(value) {
   };
 }
 
-function optional(value) {
-  return choice(value, blank());
+function optional(...value) {
+  return choice(normalize(value), blank());
 }
 
 function normalize(value) {
@@ -168,6 +168,11 @@ function normalize(value) {
         return String.fromCharCode(parseInt(group, 16));
       }
     ));
+  case Array:
+    if (!value.length) return blank()
+    return value.length === 1
+        ? normalize(value[0])
+        : normalize(seq(...value));
   case ReferenceError:
     throw value
   default:

--- a/test/grammar_test.js
+++ b/test/grammar_test.js
@@ -104,6 +104,28 @@ describe("Writing a grammar", () => {
       });
     });
 
+    describe("array", () => {
+      it("matches a sequence of rules", () => {
+        const language = generateAndLoadLanguage(
+          grammar({
+            name: "test_grammar",
+            rules: {
+              the_rule: $ => ["the", " ", "strings"]
+            }
+          })
+        );
+
+        parser.setLanguage(language);
+
+        tree = parser.parse("the strings");
+        assert.equal(tree.rootNode.toString(), "(the_rule)");
+
+        tree = parser.parse("another-string");
+        assert.equal(tree.rootNode.toString(),
+          "(ERROR (ERROR (UNEXPECTED 'a')) (UNEXPECTED 'r'))");
+      });
+    });
+
     describe("repeat", () => {
       it("applies the given rule any number of times", () => {
         const language = generateAndLoadLanguage(
@@ -124,6 +146,28 @@ describe("Writing a grammar", () => {
         assert.equal(tree.rootNode.toString(), "(the_rule)");
 
         tree = parser.parse("ooo");
+        assert.equal(tree.rootNode.toString(), "(the_rule)");
+      });
+
+      it("implicitly sequences multiple arguments", () => {
+        const language = generateAndLoadLanguage(
+          grammar({
+            name: "test_grammar",
+            rules: {
+              the_rule: $ => repeat("h", "i")
+            }
+          })
+        );
+
+        parser.setLanguage(language);
+
+        tree = parser.parse("");
+        assert.equal(tree.rootNode.toString(), "(the_rule)");
+
+        tree = parser.parse("hi");
+        assert.equal(tree.rootNode.toString(), "(the_rule)");
+
+        tree = parser.parse("hihi");
         assert.equal(tree.rootNode.toString(), "(the_rule)");
       });
     });


### PR DESCRIPTION
This PR is purely ergonomic. I find that I keep doing things like this:

```js
optional(',', $.decimal_digits)
```

(instead of 
```js
optional(seq(',', $.decimal_digits))
```
)

My time-of-confusion is dropping, but I'm still doing it occasionally, so I figure maybe it's worth just making it work.

As an also-nice-I-think side effect, this PR means we'll now interpret arrays as sequences when they occur as rule bodies.