### PR TITLE
Check for non-word characters in grammar name

### DIFF
--- a/lib/api/dsl.js
+++ b/lib/api/dsl.js
@@ -228,6 +228,10 @@ function grammar(baseGrammar, options) {
     throw new Error("Grammar's 'name' property must be a string.");
   }
 
+  if (/\W/.test(name)) {
+    throw new Error("Grammar's 'name' property cannot contain non-word characters.");
+  }
+
   let rules = Object.assign({}, baseGrammar.rules);
   if (options.rules) {
     if (typeof options.rules !== "object") {


### PR DESCRIPTION
I spent too long trying to think of the most succinct way to express this.

I don't know how to build and run the tests, so I'm hoping this is simple enough to not break anything.

Fixes #39 