### PR TITLE
Add build subcommand

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -48,23 +48,12 @@ switch (subcommand) {
       ]);
 
     require("./lib/cli/generate")({}, () => {
-      try {
-        if (!fs.existsSync(path.join('build', 'config.gypi'))) {
-          execFileSync('node-gyp', ['configure'], {stdio: 'inherit'})
-        }
-        execFileSync('node-gyp', ['build', ...args], {stdio: 'inherit'})
-      } catch (error) {
-        if (error.code === 'ENOENT') {
-            console.error([
-            'You need to install node-gyp separately to use this command',
-            '',
-            'Consider installing it globally, like this:',
-            '',
-            '  npm install --global node-gyp',
-            '',
-          ].join('\n'));
-        }
+      const nodeGyp = require.resolve('node-gyp/bin/node-gyp.js');
+      if (!fs.existsSync(path.join('build', 'config.gypi'))) {
+        execFileSync(nodeGyp, ['configure'], {stdio: 'inherit'});
       }
+      execFileSync(nodeGyp, ['build', ...args], {stdio: 'inherit'});
+      process.exit(0)
     });
     break;
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
+    "node-gyp": "^3.8.0",
     "prettier": "^1.12.1",
     "temp": "0.8.x",
     "tree-sitter": "^0.13.15",


### PR DESCRIPTION
Fixes https://github.com/tree-sitter/tree-sitter-cli/issues/43

This PR adds a `tree-sitter build` subcommand. It behaves like `tree-sitter generate && node-gyp build`. It will also run `node-gyp configure` if you have not built yet.

I haven't added `node-gyp` as an actual dependency for now, since it's an optional convenience. I just added an error message that suggests installing it if you try to run `tree-sitter build` without it.

/cc @superlou @Aerijo 