### PR TITLE
Compile property sheets to state machines

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,7 +35,8 @@ switch (subcommand) {
 
     require("./lib/cli/generate")({
       profile: argv.profile || argv.P,
-      debug: argv.debug || argv.d
+      debug: argv.debug || argv.d,
+      properties: argv.properties
     }, process.exit);
     break;
 
@@ -86,7 +87,8 @@ switch (subcommand) {
       profile: argv.profile || argv.P,
       heapProfile: argv.heap || argv.H,
       repeat: argv.repeat,
-      edits: argv.edit
+      edits: argv.edit,
+      properties: argv.properties
     }, process.exit);
     break;
 

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -2,6 +2,9 @@ const fs = require("fs");
 const path = require("path");
 const tmp = require("temp");
 const {spawnSync} = require("child_process");
+const binding = require("./binding");
+const properties = require('./properties');
+const dsl = require("./dsl");
 
 const INCLUDE_PATH = path.join(__dirname, '..', '..', 'vendor', 'tree-sitter', 'include')
 
@@ -54,11 +57,18 @@ function loadLanguage(code, otherSourceFiles = []) {
 }
 
 function generate(grammar, logToStderr) {
-  return require("./binding").generate(JSON.stringify(grammar), logToStderr)
+  return binding.generateParserCode(JSON.stringify(grammar), logToStderr);
+}
+
+function generatePropertyJSON(css, logToStderr) {
+  return binding.generatePropertyJSON(JSON.stringify(properties.parseProperties(css)), logToStderr);
 }
 
 module.exports = {
-  generate: generate,
-  loadLanguage: loadLanguage,
-  dsl: require("./dsl"),
+  generate,
+  generatePropertyJSON,
+  loadLanguage,
+  dsl,
+  parseProperties: properties.parseProperties,
+  queryProperties: properties.queryProperties
 };

--- a/lib/api/properties.js
+++ b/lib/api/properties.js
@@ -1,0 +1,219 @@
+const assert = require('assert');
+const parseCSS = require('scss-parser').parse;
+
+// Test a property state machine against a node structure
+// specified as an array of node types.
+function queryProperties(props, nodeTypeStack, childIndexStack = [], text) {
+  let stateId = 0
+  for (let i = 0, {length} = nodeTypeStack; i < length; i++) {
+    const nodeType = nodeTypeStack[i];
+    const state = props.states[stateId];
+    let found_transition = false;
+    for (const transition of state.transitions) {
+      if (
+        (transition.type === nodeType) &&
+        (transition.index == null || transition.index === childIndexStack[i]) &&
+        (transition.text == null || new RegExp(transition.text).test(text))
+      ) {
+        stateId = transition.state_id;
+        found_transition = true;
+        break;
+      }
+    }
+    if (!found_transition) {
+      stateId = state.default_next_state_id
+    }
+    // console.log(
+    //   nodeType, '->', stateId,
+    //   props.property_sets[props.states[stateId].property_set_id]
+    // );
+  }
+  return props.property_sets[props.states[stateId].property_set_id]
+}
+
+// Parse a property sheet written in CSS into the intermediate
+// object structure that is passed to the `ts_compile_property_sheet`
+// function.
+function parseProperties(source) {
+  // Get the raw SCSS concrete syntax tree.
+  const rawTree = parseCSS(stripWhitespace(source));
+
+  // Convert the concrete syntax tree into a more convenient AST.
+  removeWhitespace(rawTree);
+  const rootRules = rawTree.value.map(r => visitRule(r, false));
+
+  // Flatten out any nested selectors.
+  const rules = []
+  for (const rootRule of rootRules) {
+    flattenRule(rootRule, rules, [[]])
+  }
+
+  for (const rule of rules) {
+    rule.selectors = rule.selectors.map(applyPseudoClasses)
+  }
+
+  return rules;
+}
+
+function applyPseudoClasses(rule) {
+  const result = []
+  for (const entry of rule) {
+    if (entry.pseudo) {
+      result[result.length - 1] = Object.assign({}, result[result.length - 1], entry.pseudo)
+    } else {
+      result.push(entry)
+    }
+  }
+  return result
+}
+
+function flattenRule(node, flatRules, prefixes) {
+  const newSelectors = []
+
+  for (const prefix of prefixes) {
+    for (const selector of node.selectors) {
+      newSelectors.push(prefix.concat(selector))
+    }
+  }
+
+  flatRules.push({
+    selectors: newSelectors,
+    properties: node.properties
+  })
+
+  for (const childNode of node.rules) {
+    flattenRule(childNode, flatRules, newSelectors);
+  }
+}
+
+function visitRule(tree, nested) {
+  assert.equal(tree.type, 'rule');
+  removeWhitespace(tree);
+  assert.equal(tree.value.length, 2);
+  return {
+    selectors: visitSelectors(tree.value[0], nested),
+    ...visitBlock(tree.value[1])
+  };
+}
+
+function visitSelectors(tree, nested) {
+  assert.equal(tree.type, 'selector');
+  const selectors = [];
+  let selector = [];
+  let expectAmpersand = nested;
+  for (const entry of tree.value) {
+    if (entry.value === ',') {
+      assert.notEqual(selector.length, 0);
+      selectors.push(visitSelector(selector, nested));
+      selector = [];
+      expectAmpersand = nested
+    } else if (expectAmpersand) {
+      assert.equal(entry.value, '&')
+      expectAmpersand = false
+    } else {
+      selector.push(entry);
+    }
+  }
+  assert.notEqual(selector.length, 0);
+  selectors.push(visitSelector(selector, nested));
+  return selectors;
+}
+
+function visitSelector(selector, nested) {
+  const result = [];
+  let immediate = false;
+  let previousEntryWasNodeType = false;
+  for (let i = 0, {length} = selector; i < length; i++) {
+    const entry = selector[i];
+    if (entry.type === 'operator' && entry.value === '>') {
+      immediate = true
+      previousEntryWasNodeType = false;
+    } else if (entry.type === 'identifier' || entry.type === 'string_double') {
+      let named = entry.type === 'identifier';
+      result.push({
+        type: entry.value,
+        named,
+        immediate
+      })
+      immediate = false
+      previousEntryWasNodeType = true;
+    } else if (entry.type === 'function') {
+      const pseudo = entry.value[0].value[0].value;
+
+      let hasPrecedingNodeType = (i === 0)
+        ? nested
+        : previousEntryWasNodeType
+
+      if (!previousEntryWasNodeType && !(nested && i === 0)) {
+        throw new Error(`Pseudo class ':${pseudo}' must be used together with a node type`)
+      }
+
+      if (pseudo === 'nth-child') {
+        const args = entry.value[1];
+        assert.equal(args.type, 'arguments');
+        result.push({pseudo: {index: parseInt(args.value[0].value, 10)}})
+      } else if (pseudo === 'text') {
+        const args = entry.value[1];
+        assert.equal(args.type, 'arguments');
+        assert.equal(args.value.length, 1)
+        result.push({pseudo: {text: args.value[0].value}})
+      }
+      previousEntryWasNodeType = false;
+    } else {
+      previousEntryWasNodeType = false;
+    }
+  }
+  return result;
+}
+
+function visitBlock(tree) {
+  assert.equal(tree.type, 'block');
+  removeWhitespace(tree);
+  const properties = {};
+  const rules = [];
+  for (const entry of tree.value) {
+    if (entry.type === 'declaration') {
+      const {key, value} = visitDeclaration(entry);
+      properties[key] = value;
+    } else {
+      rules.push(visitRule(entry, true));
+    }
+  }
+  return {properties, rules};
+}
+
+function visitDeclaration(tree) {
+  assert.equal(tree.type, 'declaration');
+  removeWhitespace(tree);
+  const property = tree.value[0];
+  const value = tree.value[2];
+
+  removeWhitespace(property);
+  removeWhitespace(value);
+  assert.equal(property.type, 'property')
+  assert.equal(value.type, 'value')
+  return {
+    key: property.value[0].value,
+    value: value.value[0].value
+  };
+}
+
+// Get rid of useless nodes and properties.
+function removeWhitespace(node) {
+  node.value = node.value.filter(node => (
+    node.type !== 'space' &&
+    node.type !== 'comment_multiline' &&
+    node.type !== 'comment_singleline'
+  ))
+}
+
+// Remove whitespace so there will be fewer useless
+// nodes to deal with.
+function stripWhitespace(source) {
+  return source
+    .replace(/\/\/.*/g, '')
+    .replace(/\s+/g, ' ')
+    .replace(/\s*([{},>&;])\s*/g, '$1')
+}
+
+module.exports = {parseProperties, queryProperties}

--- a/lib/cli/generate.js
+++ b/lib/cli/generate.js
@@ -25,18 +25,6 @@ module.exports = function generate(options, callback) {
     grammar = require(path.join(cwd, "grammar"));
   }
 
-  let code;
-  try {
-    code = api.generate(grammar, options.debug);
-  } catch (e) {
-    if (e.isGrammarError) {
-      console.warn("Error: " + e.message);
-      return callback(1);
-    } else {
-      throw e;
-    }
-  }
-
   const srcPath = path.join(cwd, 'src');
   const grammarJSONPath = path.join(srcPath, 'grammar.json');
   const parserPath = path.join(srcPath, 'parser.c');
@@ -47,11 +35,42 @@ module.exports = function generate(options, callback) {
   mkdirp.sync(srcPath);
   mkdirp.sync(path.join(srcPath, "tree_sitter"));
 
+  let code;
+  if (!options.properties) {
+    try {
+      code = api.generate(grammar, options.debug);
+    } catch (e) {
+      if (e.isGrammarError) {
+        console.warn("Error: " + e.message);
+        return callback(1);
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  const propertiesPath = path.join(cwd, 'properties')
+  let propertiesFilenames = []
+  try {
+    propertiesFilenames = fs.readdirSync(propertiesPath).filter(p => p.endsWith('.css'))
+  } catch (_) {}
+
+  for (const propertiesFilename of propertiesFilenames) {
+    const propertiesCSS = fs.readFileSync(path.join(propertiesPath, propertiesFilename), 'utf8');
+    const propertiesJSON = api.generatePropertyJSON(propertiesCSS);
+    fs.writeFileSync(
+      path.join(srcPath, propertiesFilename.replace(/\.css$/, '.json')),
+      JSON.stringify(JSON.parse(propertiesJSON), null, 2)
+    )
+  }
+
   const headerPath = path.join(__dirname, "..", "..", "vendor", "tree-sitter", "include", "tree_sitter");
   fs.copySync(path.join(headerPath, "parser.h"), path.join(srcPath, "tree_sitter", "parser.h"));
 
   fs.writeFileSync(grammarJSONPath, JSON.stringify(grammar, null, 2));
-  fs.writeFileSync(parserPath, code);
+  if (code) {
+    fs.writeFileSync(parserPath, code);
+  }
 
   if (!fs.existsSync(bindingCCPath)) {
     fs.writeFileSync(bindingCCPath, templates.bindingCC(grammar.name));

--- a/lib/cli/parse.js
+++ b/lib/cli/parse.js
@@ -1,3 +1,5 @@
+const {queryProperties} = require('../api/properties');
+
 module.exports = function parse(options, callback) {
   const fs = require("fs");
   const path = require("path");
@@ -180,7 +182,11 @@ module.exports = function parse(options, callback) {
     const [seconds, nanoseconds] = process.hrtime(t0)
 
     if (!options.quiet && !options.debug && !options.debugGraph) {
-      printNode(tree.rootNode, 0);
+      let propertiesJSON
+      if (options.properties) {
+        propertiesJSON = require(path.join(cwd, 'src', options.properties + '.json'))
+      }
+      printNode(tree.rootNode, [], propertiesJSON);
       process.stdout.write("\n");
     }
 
@@ -214,7 +220,8 @@ function firstErrorDescription(node) {
   }
 }
 
-function printNode(node, indentLevel) {
+function printNode(node, stack, propertiesJSON) {
+  const indentLevel = stack.length;
   process.stdout.write(' '.repeat(2 * indentLevel));
   process.stdout.write("(");
   process.stdout.write(node.isMissing() ? 'MISSING' : node.type);
@@ -223,11 +230,22 @@ function printNode(node, indentLevel) {
   process.stdout.write(" - ");
   process.stdout.write(pointString(node.endPosition));
 
+  stack.push(node.type)
+
+  if (propertiesJSON) {
+    const props = queryProperties(propertiesJSON, stack, [], node.text)
+    for (const key in props) {
+      process.stdout.write(`, ${key}: ${props[key]}`)
+    }
+  }
+
   const {namedChildren} = node;
   for (let i = 0, length = namedChildren.length; i < length; i++) {
     process.stdout.write("\n");
-    printNode(namedChildren[i], indentLevel + 1);
+    printNode(namedChildren[i], stack, propertiesJSON);
   }
+
+  stack.pop()
 
   process.stdout.write(")");
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
     "prettier": "^1.12.1",
+    "scss-parser": "^1.0.0",
     "temp": "0.8.x",
     "tree-sitter": "^0.13.15",
     "vows": "0.7.x"

--- a/src/binding.cc
+++ b/src/binding.cc
@@ -12,8 +12,11 @@ using namespace v8;
 void InitAll(Handle<Object> exports) {
   node_tree_sitter_cli::InitLanguage(exports);
   exports->Set(
-      Nan::New("generate").ToLocalChecked(),
-      Nan::New<FunctionTemplate>(Generate)->GetFunction());
+      Nan::New("generateParserCode").ToLocalChecked(),
+      Nan::New<FunctionTemplate>(GenerateParserCode)->GetFunction());
+  exports->Set(
+      Nan::New("generatePropertyJSON").ToLocalChecked(),
+      Nan::New<FunctionTemplate>(GeneratePropertyJSON)->GetFunction());
   exports->Set(
       Nan::New("loadLanguage").ToLocalChecked(),
       Nan::New<FunctionTemplate>(LoadLanguage)->GetFunction());

--- a/src/generate.cc
+++ b/src/generate.cc
@@ -6,7 +6,7 @@ namespace node_tree_sitter_cli {
 
 using namespace v8;
 
-void Generate(const Nan::FunctionCallbackInfo<Value> &info) {
+void GenerateParserCode(const Nan::FunctionCallbackInfo<Value> &info) {
   String::Utf8Value grammar_json(info[0]);
 
   FILE *log_file;
@@ -17,6 +17,27 @@ void Generate(const Nan::FunctionCallbackInfo<Value> &info) {
   }
 
   TSCompileResult result = ts_compile_grammar(*grammar_json, log_file);
+
+  if (result.error_type != TSCompileErrorTypeNone) {
+    Local<Value> error = Nan::Error(result.error_message);
+    Local<Object>::Cast(error)->Set(Nan::New("isGrammarError").ToLocalChecked(), Nan::True());
+    Nan::ThrowError(error);
+  } else {
+    info.GetReturnValue().Set(Nan::New(result.code).ToLocalChecked());
+  }
+}
+
+void GeneratePropertyJSON(const Nan::FunctionCallbackInfo<Value> &info) {
+  String::Utf8Value property_sheet_json(info[0]);
+
+  FILE *log_file;
+  if (info.Length() > 1 && info[1]->BooleanValue()) {
+    log_file = stderr;
+  } else {
+    log_file = nullptr;
+  }
+
+  TSCompileResult result = ts_compile_property_sheet(*property_sheet_json, log_file);
 
   if (result.error_type != TSCompileErrorTypeNone) {
     Local<Value> error = Nan::Error(result.error_message);

--- a/src/generate.h
+++ b/src/generate.h
@@ -6,7 +6,8 @@
 
 namespace node_tree_sitter_cli {
 
-void Generate(const Nan::FunctionCallbackInfo<v8::Value> &);
+void GenerateParserCode(const Nan::FunctionCallbackInfo<v8::Value> &);
+void GeneratePropertyJSON(const Nan::FunctionCallbackInfo<v8::Value> &);
 
 }  // namespace node_tree_sitter_cli
 

--- a/test/properties_test.js
+++ b/test/properties_test.js
@@ -1,0 +1,170 @@
+const assert = require('assert');
+const {parseProperties, generatePropertyJSON, queryProperties} = require('..');
+
+describe('grammar properties', () => {
+  describe(".parseProperties(css)", () => {
+    it('parses pseudo classes', () => {
+      const css = `
+        arrow_function > identifier:nth-child(0) {
+          define: local;
+        }
+      `;
+
+      assert.deepEqual(parseProperties(css), [
+        {
+          selectors: [
+            [
+              {type: 'arrow_function', immediate: false, named: true},
+              {type: 'identifier', immediate: true, named: true, index: 0}
+            ]
+          ],
+          properties: {define: 'local'}
+        }
+      ])
+    })
+
+    it('parses nested selectors', async () => {
+      const css = `
+        a, b {
+          p: q;
+
+          & > c > d, & e {
+            p: w;
+          }
+        }
+      `;
+
+      assert.deepEqual(await parseProperties(css), [
+        {
+          selectors: [
+            [
+              {type: 'a', immediate: false, named: true},
+            ],
+            [
+              {type: 'b', immediate: false, named: true},
+            ]
+          ],
+          properties: {p: 'q'}
+        },
+        {
+          selectors: [
+            [
+              {type: 'a', immediate: false, named: true},
+              {type: 'c', named: true, immediate: true},
+              {type: 'd', named: true, immediate: true}
+            ],
+            [
+              {type: 'a', immediate: false, named: true},
+              {type: 'e', named: true, immediate: false}
+            ],
+            [
+              {type: 'b', immediate: false, named: true},
+              {type: 'c', named: true, immediate: true},
+              {type: 'd', named: true, immediate: true},
+            ],
+            [
+              {type: 'b', immediate: false, named: true},
+              {type: 'e', named: true, immediate: false}
+            ]
+          ],
+          properties: {p: 'w'}
+        }
+      ])
+    })
+  });
+
+  describe('.generatePropertyJSON and .queryProperties', () => {
+    it('handles immediate child selectors', () => {
+      const css = `
+        f1 {
+          color: red;
+
+          & > f2 {
+            color: green;
+          }
+
+          & f3 {
+            color: blue;
+          }
+        }
+
+        f2 {
+          color: indigo;
+          height: 2;
+        }
+
+        f3 {
+          color: violet;
+          height: 3;
+        }
+      `;
+
+      const properties = JSON.parse(generatePropertyJSON(css));
+
+      // f1 single-element selector
+      assert.deepEqual(queryProperties(properties, ['f1']), {color: 'red'})
+      assert.deepEqual(queryProperties(properties, ['f2', 'f1']), {color: 'red'})
+      assert.deepEqual(queryProperties(properties, ['f2', 'f3', 'f1']), {color: 'red'})
+
+      // f2 single-element selector
+      assert.deepEqual(queryProperties(properties, ['f2']), {color: 'indigo', height: '2'})
+      assert.deepEqual(queryProperties(properties, ['f2', 'f2']), {color: 'indigo', height: '2'})
+      assert.deepEqual(queryProperties(properties, ['f1', 'f3', 'f2']), {color: 'indigo', height: '2'})
+      assert.deepEqual(queryProperties(properties, ['f1', 'f6', 'f2']), {color: 'indigo', height: '2'})
+
+      // f3 single-element selector
+      assert.deepEqual(queryProperties(properties, ['f3']), {color: 'violet', height: '3'})
+      assert.deepEqual(queryProperties(properties, ['f2', 'f3']), {color: 'violet', height: '3'})
+
+      // f2 child selector
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2']), {color: 'green', height: '2'})
+      assert.deepEqual(queryProperties(properties, ['f2', 'f1', 'f2']), {color: 'green', height: '2'})
+      assert.deepEqual(queryProperties(properties, ['f3', 'f1', 'f2']), {color: 'green', height: '2'})
+
+      // f3 descendant selector
+      assert.deepEqual(queryProperties(properties, ['f1', 'f3']), {color: 'blue', height: '3'})
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2', 'f3']), {color: 'blue', height: '3'})
+      assert.deepEqual(queryProperties(properties, ['f1', 'f6', 'f7', 'f8', 'f3']), {color: 'blue', height: '3'})
+
+      // no match
+      assert.deepEqual(queryProperties(properties, ['f1', 'f3', 'f4']), {})
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2', 'f5']), {})
+    });
+
+    it('handles the :text pseudo class', () => {
+      const css = `
+        f1 {
+          color: red;
+
+          &:text('^[A-Z]') {
+            color: green;
+          }
+        }
+
+        f2:text('^[A-Z_]+$') {
+          color: purple;
+        }
+      `;
+
+      const properties = JSON.parse(generatePropertyJSON(css));
+      assert.deepEqual(queryProperties(properties, ['f1'], [0], 'abc'), {color: 'red'});
+      assert.deepEqual(queryProperties(properties, ['f1'], [0], 'Abc'), {color: 'green'});
+      assert.deepEqual(queryProperties(properties, ['f2'], [0], 'abc'), {});
+      assert.deepEqual(queryProperties(properties, ['f2'], [0], 'ABC'), {color: 'purple'});
+    });
+
+    it('does not allow pseudo classes to be used without a node type', () => {
+      assert.throws(() => {
+        generatePropertyJSON(`:text('a') {}`)
+      }, /Pseudo class ':text' must be used together with a node type/)
+
+      assert.throws(() => {
+        generatePropertyJSON(`a :text('a') {}`)
+      }, /Pseudo class ':text' must be used together with a node type/)
+
+      assert.throws(() => {
+        generatePropertyJSON(`a > :nth-child(0) {}`)
+      }, /Pseudo class ':nth-child' must be used together with a node type/)
+    });
+  });
+});

--- a/test/properties_test.js
+++ b/test/properties_test.js
@@ -166,5 +166,21 @@ describe('grammar properties', () => {
         generatePropertyJSON(`a > :nth-child(0) {}`)
       }, /Pseudo class ':nth-child' must be used together with a node type/)
     });
+
+    it('breaks specificity ties using the order in the cascade', () => {
+      const css = `
+        f1 f2:nth-child(1) { color: red; }
+        f1:nth-child(1) f2 { color: green; }
+        f1 f2:text('a') { color: blue; }
+        f1 f2:text('b') { color: violet; }
+      `;
+
+      const properties = JSON.parse(generatePropertyJSON(css));
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2'], [0, 0], 'x'), {});
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2'], [0, 1], 'x'), {color: 'red'});
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2'], [1, 1], 'x'), {color: 'green'});
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2'], [1, 1], 'a'), {color: 'blue'});
+      assert.deepEqual(queryProperties(properties, ['f1', 'f2'], [1, 1], 'ab'), {color: 'violet'});
+    })
   });
 });


### PR DESCRIPTION
Depends on https://github.com/tree-sitter/tree-sitter/pull/204

* During `generate`, read all `.css` files in the `properties` directory, use the `ts_compile_property_sheet` function to convert them into state machines, and save them as JSON files in `src`.
* Add tests for property sheet compilation
* Add a `--properties <sheet-name>` flag to the `parse` command so that you can see the properties that apply to each node.