### PR TITLE
Use Object cast for safe property access

### DIFF
--- a/lib/api/dsl.js
+++ b/lib/api/dsl.js
@@ -81,7 +81,7 @@ function alias(rule, value) {
     content: normalize(rule)
   };
 
-  switch (value.constructor) {
+  switch (Object(value).constructor) {
   case String:
     result.named = false;
     result.value = value;
@@ -158,7 +158,7 @@ function normalize(value) {
   if (typeof value == "undefined")
     throw new Error("Undefined symbol");
 
-  switch (value.constructor) {
+  switch (Object(value).constructor) {
   case String:
     return string(value);
   case RegExp:
@@ -170,12 +170,13 @@ function normalize(value) {
     ));
   case ReferenceError:
     throw value
-  default:
+  case Object:
     if (typeof value.type === 'string') {
       return value;
-    } else {
-      throw new TypeError("Invalid rule: " + value.toString());
     }
+    // fall through
+  default:
+      throw new TypeError("Invalid rule: " + value.toString());
   }
 }
 


### PR DESCRIPTION
Without these you'll get this error:
`TypeError: Cannot read property 'constructor' of undefined`